### PR TITLE
WebSocketのprotocolをwssに変更する

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,7 +223,7 @@
 </div>
 
 <script>
-    var ws = new WebSocket('ws://pure-dusk-5665.herokuapp.com');
+    var ws = new WebSocket('wss://pure-dusk-5665.herokuapp.com');
 
     ws.onopen = function () {
         ws.send(String.fromCharCode(100));

--- a/js/tkm-initialize.js
+++ b/js/tkm-initialize.js
@@ -16,7 +16,7 @@ Tkm.Sound.PASS = 8;
 Tkm.Sound.ROBBER = 9;
 
 Tkm.view = null;
-Tkm.wsurl = 'ws://pure-dusk-5665.herokuapp.com';
+Tkm.wsurl = 'wss://pure-dusk-5665.herokuapp.com';
 Tkm.ws = null;
 Tkm.roomIndex = null;
 Tkm.userList = [];


### PR DESCRIPTION
FirefoxやChromeだとhttpsのサイトからはWebSocket Secure (wss) でないと接続できないみたいなので、wsをwssに変更しました。